### PR TITLE
wigner_rotation_matrix.m has been modified to produce consistent resu…

### DIFF
--- a/examples/example_hgmode_beam.m
+++ b/examples/example_hgmode_beam.m
@@ -99,7 +99,7 @@ ci=union(cia,cib);
 
 [n,m]=combined_index(ci);
 %%
-Es=electromagnetic_field_xyz(2*pi*[X(:),Y(:),Z(:)],[n;m],[a_full;b_full]);
+Es=electromagnetic_field_xyz(2*pi*[X(:),Y(:),Z(:)],[n;m],[a_full;b_full],[],[]);
 
 E2=sum(abs(Es.Eincident).^2,2);
 H2=sum(abs(Es.Hincident).^2,2);

--- a/ott-toolbox/bsc_bessel_farfield.m
+++ b/ott-toolbox/bsc_bessel_farfield.m
@@ -29,6 +29,8 @@ function [nn,mm,a,b] = bsc_bessel_farfield( nmax, beam_type, parameters )
 %
 % PACKAGE INFO
 
+warning('ott:bsc_bessel_farfield:depreciated','This function will be replaced by bsc_bessel.m in ott1.4 which uses an analytical solution for bessel beams instead of pointmatching.')
+
 axisymmetry = 1;
 %axisymmetry = 0;
 

--- a/ott-toolbox/bsc_pointmatch_farfield.m
+++ b/ott-toolbox/bsc_pointmatch_farfield.m
@@ -60,7 +60,7 @@ switch beam_type
         [modeweights,initial_mode,final_mode]=paraxial_transformation_matrix(paraxial_order,0,1,0);
         [row]=find(final_mode(:,1)==m,1);
     case 1
-        paraxial_order=2*radial_mode+azimuthal_mode;
+        paraxial_order=2*radial_mode+abs(azimuthal_mode);
         modeweights=eye(paraxial_order+1);
         row=(azimuthal_mode+paraxial_order)/2+1;
         
@@ -139,7 +139,7 @@ if axisymmetry
     ntheta = 2*(nmax+1);
     nphi = 3;
     if beam_type~=1
-        nphi = paraxial_order+3;
+        nphi = paraxial_order+3-rem(paraxial_order,2);
     end
 end
 

--- a/ott-toolbox/electromagnetic_field_xyz.m
+++ b/ott-toolbox/electromagnetic_field_xyz.m
@@ -534,9 +534,9 @@ if verbose
     toc
 end
 
-% H1=-1i*H1; %LOOK HERE TO FIX STUFF
-% H2=-1i*H2; %LOOK HERE TO FIX STUFF
-% H3=-1i*H3; %LOOK HERE TO FIX STUFF
+ H1=-1i*H1; %LOOK HERE TO FIX STUFF
+ H2=-1i*H2; %LOOK HERE TO FIX STUFF
+ H3=-1i*H3; %LOOK HERE TO FIX STUFF
 
 
 %res flipped because it's a meshgrid

--- a/ott-toolbox/farfield.m
+++ b/ott-toolbox/farfield.m
@@ -66,6 +66,6 @@ E=[zeros(size(Etheta)),Etheta,Ephi];
 H=[zeros(size(Htheta)),Htheta,Hphi];
 
 % SI-ify units of H
-%H = H * -1i;
+H = H * -1i;
 
 return

--- a/ott-toolbox/force_torque_farsund.m
+++ b/ott-toolbox/force_torque_farsund.m
@@ -25,6 +25,16 @@ function [fx,fy,fz,tx,ty,tz,sx,sy,sz]=force_torque_farsund(n,m,a,b,p,q)
 warning('ott:force_torque_farsund:depreciated', ...
     'This file will replace forcetorque.m in the next release');
 
+fx=0;
+fy=0;
+fz=0;
+tx=0;
+ty=0;
+tz=0;
+sx=0;
+sy=0;
+sz=0;
+
 nmax=max(n);
 
 b=1i*b;
@@ -98,8 +108,8 @@ Bxy=1i./(n+1).*sqrt(n.*(n+2))./sqrt((2*n+1).*(2*n+3)).* ... %sqrt(n.*)
     sqrt((n-m+1).*(n-m+2)) .* (pnp1mm1.*conj(p) + qnp1mm1.*conj(q) - anp1mm1.*conj(a) - bnp1mm1.*conj(b)) ); %this has the correct sign... farsund. modes match.
 
 fxy=sum(Axy+Bxy);
-fx=-real(fxy);
-fy=-imag(fxy);
+fx=real(fxy);
+fy=imag(fxy);
 
 if nargout > 1
     tz=sum(m.*(a.*conj(a)+b.*conj(b)-p.*conj(p)-q.*conj(q))); %this has the correct sign... farsund. modes match.
@@ -114,7 +124,7 @@ if nargout > 1
             .*real(anp1.*conj(b)-bnp1.*conj(a)-(pnp1).*conj(q) ...
             +(qnp1).*conj(p));
         
-        sz = -sum(Cz+Dz);
+        sz = sum(Cz+Dz);
         
         Cxy=1i./n./(n+1).*sqrt((n-m).*(n+m+1)).*(conj(pmp1).*p - conj(amp1).*a + conj(qmp1).*q - conj(bmp1).*b);
         Dxy=1i./(n+1).*sqrt(n.*(n+2))./sqrt((2*n+1).*(2*n+3)).* ...
@@ -123,7 +133,7 @@ if nargout > 1
         
         sxy=sum(Cxy+Dxy);
         sy=real(sxy);
-        sx=-imag(sxy);
+        sx=imag(sxy);
     end
 end
 

--- a/ott-toolbox/forcetorque.m
+++ b/ott-toolbox/forcetorque.m
@@ -73,7 +73,7 @@ m2 = m2(:);
 
 % First, rotate x axis onto z axis
 
-R = calc_rotation_matrix([0 pi/2 0]);
+R = calc_rotation_matrix([0 -pi/2 0]);
 D = wigner_rotation_matrix(max(n),R);
 D = D(:,ci);
 
@@ -88,7 +88,7 @@ spin(1) = spinz(n2,m2,a2,b2) - spinz(n2,m2,p2,q2);
 
 % Finally, rotate (original) y axis onto z axis
 
-R = calc_rotation_matrix([pi/2 0 0]);
+R = calc_rotation_matrix([-pi/2 0 0]);
 D = wigner_rotation_matrix(max(n),R);
 D = D(:,ci);
 

--- a/ott-toolbox/lg_mode_w0.m
+++ b/ott-toolbox/lg_mode_w0.m
@@ -5,7 +5,7 @@ function w0 = lg_mode_w0( mode, angle )
 % w0 = lg_mode_w0( mode, angle );
 % where:
 % w0 is the waist parameter in units of wavelength
-% mode = [ p l ] [BUT CURRENTLY p MUST BE ZERO]
+% mode = [ p l ] 
 %  or
 % mode = l (and p = 0 is assumed)
 % angle = 1/e^2 angle in degrees
@@ -47,9 +47,9 @@ psi3 = [ -4.859972437674526e-006;
    9.47541396001228 ];
 
 if length(mode) > 1
-   l = abs(mode(2));
+   l = 2*mode(1)+abs(mode(2));
 else
-   l = mode;
+   l = abs(mode);
 end
 
 if l == 0

--- a/ott-toolbox/translate_z.m
+++ b/ott-toolbox/translate_z.m
@@ -7,11 +7,11 @@ function [A,B,C] = translate_z(nmax,z)
 % where
 % M' = A M + B N; N' = B M + A N
 %
-% C are the scalar SWF translation coefficients
+% C are the scalar SWF translation coefficients in 3d packed form.
 %
 % A and B are sparse matrices, since only m' = m VSWFs couple
 %
-% If z is a vector/matrix only A's and B's will be outputted. A and B will 
+% If z is a vector/matrix only A's and B's will be outputted. A and B will
 % be cells of matricies the length of the number of elements in z. To save
 % time only use unique values of z.
 %
@@ -42,7 +42,7 @@ end
 
 if z==0
     A=sparse(1:(nmax^2+nmax*2),1:(nmax^2+nmax*2),1);
-    B=0;
+    B=sparse((nmax^2+nmax*2),(nmax^2+nmax*2));
     C=A;
     return
 end
@@ -59,8 +59,6 @@ k = 0:(N-1);
 C(:,1,1) = sqrt(2*k+1) .* sbesselj(k,2*pi*z);
 if z < 0
     C(:,1,1) = sqrt(2*k+1) .* sbesselj(k,2*pi*abs(z)) .* (-1).^(k);
-else
-    C(:,1,1) = sqrt(2*k+1) .* sbesselj(k,2*pi*z);
 end
 
 % Do n=1 as a special case (Videen (40) with n=0,n'=k)
@@ -107,108 +105,70 @@ for m = 1:(N-2)
     C0 = C(kk+1,nn+1,m);
     Cp = C(kk+2,nn+1,m);
     Cm = C(kk,nn+1,m);
-%     C(kk+1,nn+1,m+1) = sqrt(1./((2*kk+1)*((nn-m+1).*(nn+m)))) .* ...
-%         ( sqrt(((kk-m+1).*(kk+m))*(2*nn+1)) .* C0 ...
-%         - 2*pi*z * sqrt(((kk-m+2).*(kk-m+1))*row1) .* Cp ...
-%         - 2*pi*z * sqrt(((kk+m).*(kk+m-1))*row1) .* Cm );
+    %     C(kk+1,nn+1,m+1) = sqrt(1./((2*kk+1)*((nn-m+1).*(nn+m)))) .* ...
+    %         ( sqrt(((kk-m+1).*(kk+m))*(2*nn+1)) .* C0 ...
+    %         - 2*pi*z * sqrt(((kk-m+2).*(kk-m+1))*row1) .* Cp ...
+    %         - 2*pi*z * sqrt(((kk+m).*(kk+m-1))*row1) .* Cm );
     C(kk+1,nn+1,m+1) = sqrt(1./((2*kk+1)*((nn-m+1).*(nn+m)))) .* ...
-        ( sqrt(((kk-m+1).*(kk+m).*(2*kk+1))*row1) .* C0 ...
-        -2*pi*z*sqrt((((kk-m+2).*(kk-m+1))*row1)./((2*kk+3)*row1)).*Cp ...
-        -2*pi*z*sqrt((((kk+m).*(kk+m-1))*row1)./((2*kk-1)*row1)).*Cm );
+        ( sqrt(((kk-m+1).*(kk+m).*(2*kk+1)))*row1 .* C0 ...
+        -2*pi*z*sqrt((((kk-m+2).*(kk-m+1)))./((2*kk+3)))*row1.*Cp ...
+        -2*pi*z*sqrt((((kk+m).*(kk+m-1)))./((2*kk-1)))*row1.*Cm );
 end
 
 % OK, that's the scalar coefficients
 % Time to find the vector coefficients - Videen (43) & (44)
 
-kkk = ones(nmax,nmax,nmax+1);
-nnn = ones(nmax,nmax,nmax+1);
-for k = 1:nmax
-    kkk(k,:,:) = k;
-    nnn(:,k,:) = k;
-end
-mmm = ones(nmax,nmax,nmax+1);
-for m = 0:nmax
-   mmm(:,:,m+1) = m;
-end
-C0 = C(2:(nmax+1),2:(nmax+1),1:(nmax+1));
-Cp = C(3:(nmax+2),2:(nmax+1),1:(nmax+1));
-Cm = C(1:nmax,2:(nmax+1),1:(nmax+1));
+[nn,kk]=meshgrid([1:nmax],[1:nmax]);
 
-A = C0 - 2*pi*z./(kkk+1) .* ...
-    sqrt((kkk-mmm+1).*(kkk+mmm+1)./((2*kkk+1).*(2*kkk+3))) .* Cp - ...
-    2*pi*z./kkk.*sqrt((kkk-mmm).*(kkk+mmm)./((2*kkk+1).*(2*kkk-1))).*Cm;
+matrixm=sqrt(kk.*(kk+1)) ./ sqrt(nn.*(nn+1));
 
-B = 1i*2*pi*z*mmm./(kkk.*(kkk+1)) .* C0;
+central_iterator=[1:nmax].*[2:nmax+1];
 
-% Videen uses a different normalisation, so adjust to our VSWFs
-A = A .* sqrt(kkk.*(kkk+1)) ./ sqrt(nnn.*(nnn+1));
-B = B .* sqrt(kkk.*(kkk+1)) ./ sqrt(nnn.*(nnn+1));
+[ciy,cix]=meshgrid(central_iterator,central_iterator);
 
-% Dump the extra values from C
-C = C(1:(nmax+1),1:(nmax+1),1:(nmax+1));
+mmm=0;
 
+C0 = C(2:(nmax+1),2:(nmax+1),mmm+1);
+Cp = C(3:(nmax+2),2:(nmax+1),mmm+1);
+Cm = C(1:nmax,2:(nmax+1),mmm+1);
 
-% Testing, testing, 1, 2, 3 ...
-%C
-%sum(C.*C,2)
-%VV = C(:,1,1);
-%sum(VV.*VV)
+t = matrixm.*(C0 - 2*pi*z./(kk+1) .* ...
+    sqrt((kk-mmm+1).*(kk+mmm+1)./((2*kk+1).*(2*kk+3))) .* Cp - ...
+    2*pi*z./kk.*sqrt((kk-mmm).*(kk+mmm)./((2*kk+1).*(2*kk-1))).*Cm);
 
-% Now stick all these values in the N_orders x N_orders translations
-% matrices. These will be sparse since they're diagonal in m.
+toIndexy=(ciy(:));
+toIndexx=(cix(:));
+A=t(:);
+B=zeros(size(A));
 
-A_elements = [];
-B_elements = [];
-C_elements = [];
-v_cols = [];
-v_rows = [];
-s_cols = [];
-s_rows = [];
-for m = 0:nmax
-    mm = max(1,m);
-    k = mm:nmax;
-    n = mm:nmax;
-    k0 = m:nmax;
-    n0 = m:nmax;
-    v_col = combined_index(k,m);
-    v_row = combined_index(n,m);
-    s_col = combined_index(k0,m) + 1;
-    s_row = combined_index(n0,m) + 1;
-    v_col_matrix = v_col' * ones(size(v_row));
-    v_row_matrix = ones(size(v_col')) * v_row;
-    s_col_matrix = s_col' * ones(size(s_row));
-    s_row_matrix = ones(size(s_col')) * s_row;
-    A_elements_matrix = A(k,n,m+1);
-    B_elements_matrix = B(k,n,m+1);
-    C_elements_matrix = C(k0+1,n0+1,m+1);
-    A_elements = [ A_elements; A_elements_matrix(:) ];
-    B_elements = [ B_elements; B_elements_matrix(:) ];
-    C_elements = [ C_elements; C_elements_matrix(:) ];
-    v_cols = [ v_cols; v_col_matrix(:) ];
-    v_rows = [ v_rows; v_row_matrix(:) ];
-    s_cols = [ s_cols; s_col_matrix(:) ];
-    s_rows = [ s_rows; s_row_matrix(:) ];
-    if m > 0
-        v_col = combined_index(k,-m);
-        v_row = combined_index(n,-m);
-        s_col = combined_index(k0,-m) + 1;
-        s_row = combined_index(n0,-m) + 1;
-        v_col_matrix = v_col' * ones(size(v_row));
-        v_row_matrix = ones(size(v_col')) * v_row;
-        s_col_matrix = s_col' * ones(size(s_row));
-        s_row_matrix = ones(size(s_col')) * s_row;
-        A_elements = [ A_elements; A_elements_matrix(:) ];
-        B_elements = [ B_elements; -B_elements_matrix(:) ];
-        C_elements = [ C_elements; C_elements_matrix(:) ];
-        v_cols = [ v_cols; v_col_matrix(:) ];
-        v_rows = [ v_rows; v_row_matrix(:) ];
-        s_cols = [ s_cols; s_col_matrix(:) ];
-        s_rows = [ s_rows; s_row_matrix(:) ];
-    end
+for mmm=1:nmax
+    C0 = C(2:(nmax+1),2:(nmax+1),mmm+1);
+    Cp = C(3:(nmax+2),2:(nmax+1),mmm+1);
+    Cm = C(1:nmax,2:(nmax+1),mmm+1);
+    
+    t = matrixm.*(C0 - 2*pi*z./(kk+1) .* ...
+        sqrt((kk-mmm+1).*(kk+mmm+1)./((2*kk+1).*(2*kk+3))) .* Cp - ...
+        2*pi*z./kk.*sqrt((kk-mmm).*(kk+mmm)./((2*kk+1).*(2*kk-1))).*Cm);
+
+    tt=t(mmm:end,mmm:end);
+    ciys=ciy(mmm:end,mmm:end);
+    cixs=cix(mmm:end,mmm:end);
+    
+    toIndexy=[toIndexy;(ciys(:)+mmm);(ciys(:)-mmm)];
+    toIndexx=[toIndexx;(cixs(:)+mmm);(cixs(:)-mmm)];
+    A=[A;tt(:);tt(:)];
+
+    t = 1i*2*pi*z*mmm./(kk.*(kk+1)).*matrixm .* C0;
+    tt=t(mmm:end,mmm:end);
+    B=[B;tt(:);-tt(:)];
+
 end
 
-A = sparse(v_rows,v_cols,A_elements);
-B = sparse(v_rows,v_cols,B_elements);
-C = sparse(s_rows,s_cols,C_elements);
+B=sparse(toIndexy,toIndexx,B,nmax*(nmax+2),nmax*(nmax+2));
+A=sparse(toIndexy,toIndexx,A,nmax*(nmax+2),nmax*(nmax+2));
+
+if nargout>2
+    C=C(1:nmax+1,1:nmax+1,1:nmax+1);
+end
 
 return

--- a/ott-toolbox/wigner_rotation_matrix.m
+++ b/ott-toolbox/wigner_rotation_matrix.m
@@ -38,12 +38,12 @@ warning('this function will move to ott.utils.wigner_rotation_matrix');
 %          0         0         1;
 %         -1/sqrt(2) i/sqrt(2) 0 ];
 
-C = [  -1/sqrt(2) 0 1/sqrt(2);
-      -1i/sqrt(2) 0 -1i/sqrt(2);
+C = [  1/sqrt(2) 0 -1/sqrt(2);
+      1i/sqrt(2) 0 1i/sqrt(2);
        0         1  0 ];
-invC = [ -1/sqrt(2) 1i/sqrt(2) 0;
+invC = [ 1/sqrt(2) -1i/sqrt(2) 0;
          0         0         1;
-         1/sqrt(2) 1i/sqrt(2) 0 ];
+         -1/sqrt(2) -1i/sqrt(2) 0 ];
 
 % Since x' = x R, s' -> x' C = s invC R C -> s' = s (invC R C)
 


### PR DESCRIPTION
…lts with input rotation matrices (calc_rotation_matrix.m, rotation_matrix.m, z_rotation_matrix.m), in previous versions it would get x or y or both components with the wrong sign. It also meant that force_torque_farsund.m used minus signs to get a consistent axis force,torque etc. This change means that force_torque_farsund.m can be used as derived by farsund.

Made a modification to bsc_pointmatch_farfield.m to deal with a negative azimuthal index, also modified it to deal with particular parities under symmetry optimisation (which it wasn't before).
lg_mode_w0.m now has the functionality that it had previously advertised. This is also necessary for the example_hgmode_beam.m code which has been modified to work with the changes to the beam shaping codes.
example_cube.m employs a dynamical simulation which now works without hacks due to the change to wigner_rotation_matrix.